### PR TITLE
First commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,7 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/cisagov/ansible-role-sshd-allow-rsa.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-sshd-allow-rsa/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/cisagov/ansible-role-sshd-allow-rsa.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/cisagov/ansible-role-sshd-allow-rsa/context:python)
 
-This is a skeleton project that can be used to quickly get a new
-[cisagov](https://github.com/cisagov) Ansible role GitHub project
-started.  This skeleton project contains
-[licensing information](LICENSE), as well as
-[pre-commit hooks](https://pre-commit.com) and
-[GitHub Actions](https://github.com/features/actions) configurations
-appropriate for an Ansible role.
+This Ansible role configures sshd to allow RSA keys.
 
 ## Requirements ##
 
@@ -40,15 +34,8 @@ Here's how to use it in a playbook:
   become: yes
   become_method: sudo
   roles:
-    - skeleton
+    - sshd_allow_rsa
 ```
-
-## New Repositories from a Skeleton ##
-
-Please see our [Project Setup guide](https://github.com/cisagov/development-guide/tree/develop/project_setup)
-for step-by-step instructions on how to start a new repository from
-a skeleton. This will save you time and effort when configuring a
-new repository!
 
 ## Contributing ##
 
@@ -70,4 +57,4 @@ with this waiver of copyright interest.
 
 ## Author Information ##
 
-First Last - <first.last@trio.dhs.gov>
+Shane Frasier - <jeremy.frasier@trio.dhs.gov>

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,10 +1,11 @@
 ---
 galaxy_info:
-  author: First Last
-  description: Skeleton Ansible role
+  author: Shane Frasier
+  description: Configure sshd to allow RSA keys
   company: CISA Cyber Assessments
   galaxy_tags:
-    - skeleton
+    - rsa
+    - sshd
   license: CC0
   # With the release of version 2.10, Ansible finally correctly
   # identifies Kali Linux as being the Kali distribution of the Debian
@@ -34,6 +35,6 @@ galaxy_info:
       versions:
         - bionic
         - focal
-  role_name: skeleton
+  role_name: sshd_allow_rsa
 
 dependencies: []

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,3 +4,13 @@
 
 - name: Import python playbook
   ansible.builtin.import_playbook: python.yml
+
+# Any host where we run this role will already have sshd installed.
+- hosts: all
+  name: Install sshd
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Install sshd
+      ansible.builtin.package:
+        name: openssh-server

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -5,12 +5,31 @@
 - name: Import python playbook
   ansible.builtin.import_playbook: python.yml
 
-# Any host where we run this role will already have sshd installed.
-- hosts: all
-  name: Install sshd
+# Any host where we run this role will already have ssh and sshd
+# installed.
+- name: Group hosts by OS distribution
+  hosts: all
+  tasks:
+    - name: Group hosts by OS family
+      ansible.builtin.group_by:
+        key: os_{{ ansible_os_family }}
+- hosts: os_RedHat
+  name: Install ssh and sshd
   become: yes
   become_method: sudo
   tasks:
-    - name: Install sshd
+    - name: Install ssh and sshd
       ansible.builtin.package:
-        name: openssh-server
+        name:
+          - openssh-clients
+          - openssh-server
+- hosts: os_Debian
+  name: Install ssh and sshd
+  become: yes
+  become_method: sudo
+  tasks:
+    - name: Install ssh and sshd
+      ansible.builtin.package:
+        name:
+          - openssh-client
+          - openssh-server

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -24,7 +24,7 @@ def test_files(host, f):
 
 
 def test_file_content(host):
-    """Verify that all file contains the expected content."""
+    """Verify that the file contains the expected content."""
     ff = host.file("/etc/ssh/sshd_config.d/99-allow-rsakeys.conf")
 
     if host.system_info.distribution in ["amzn"]:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -12,7 +12,12 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
 ).get_hosts("all")
 
 
-@pytest.mark.parametrize("x", [True])
-def test_packages(host, x):
-    """Run a dummy test, just to show what one would look like."""
-    assert x
+@pytest.mark.parametrize("f", ["/etc/ssh/sshd_config.d/99-allow-rsakeys.conf"])
+def test_files(host, f):
+    """Verify that all expected files indeed exist."""
+    ff = host.file(f)
+    assert ff.exists
+    assert ff.is_file
+    assert ff.user == "root"
+    assert ff.group == "root"
+    assert ff.mode == 0o644

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -21,3 +21,35 @@ def test_files(host, f):
     assert ff.user == "root"
     assert ff.group == "root"
     assert ff.mode == 0o644
+
+
+def test_file_content(host):
+    """Verify that all file contains the expected content."""
+    ff = host.file("/etc/ssh/sshd_config.d/99-allow-rsakeys.conf")
+
+    if host.system_info.distribution in ["amzn"]:
+        # OpenSSH pre-8.5
+        assert ff.contains("^PubkeyAcceptedKeyTypes")
+    elif host.system_info.distribution in ["debian"]:
+        if host.system_info.codename in ["stretch", "buster", "bullseye"]:
+            # OpenSSH pre-8.5
+            assert ff.contains("^PubkeyAcceptedKeyTypes")
+        elif host.system_info.codename in ["bookworm"]:
+            # OpenSSH 8.5+
+            assert ff.contains("^PubkeyAcceptedAlgorithms")
+        else:
+            assert False, f"Unknown Debian codename {host.system_info.codename}"
+    elif host.system_info.distribution in ["ubuntu"]:
+        if host.system_info.codename in ["bionic", "focal"]:
+            # OpenSSH pre-8.5
+            assert ff.contains("^PubkeyAcceptedKeyTypes")
+        elif host.system_info.codename in ["bookworm"]:
+            # OpenSSH 8.5+
+            assert ff.contains("^PubkeyAcceptedAlgorithms")
+        else:
+            assert False, f"Unknown Ubuntu codename {host.system_info.codename}"
+    elif host.system_info.distribution in ["fedora", "kali"]:
+        # OpenSSH 8.5+
+        assert ff.contains("^PubkeyAcceptedAlgorithms")
+    else:
+        assert False, f"Unknown distribution {host.system_info.distribution}"

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -43,9 +43,6 @@ def test_file_content(host):
         if host.system_info.codename in ["bionic", "focal"]:
             # OpenSSH pre-8.5
             assert ff.contains("^PubkeyAcceptedKeyTypes")
-        elif host.system_info.codename in ["bookworm"]:
-            # OpenSSH 8.5+
-            assert ff.contains("^PubkeyAcceptedAlgorithms")
         else:
             assert False, f"Unknown Ubuntu codename {host.system_info.codename}"
     elif host.system_info.distribution in ["fedora", "kali"]:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,15 @@
 ---
+- name: Determine the version of OpenSSH
+  ansible.builtin.command:
+    cmd: ssh -V
+  changed_when: false
+  register: ssh_version
+
+- name: Set facts for OpenSSH and OpenSSL versions
+  ansible.builtin.set_fact:
+    openssh_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)  .+$', '\\1') | first }}"
+    openssl_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)  .+$', '\\2') | first }}"
+
 - name: Ensure that a directory for sshd config fragments exists
   ansible.builtin.file:
     group: root
@@ -19,11 +30,24 @@
     path: /etc/ssh/sshd_config
 
 - name: Modify sshd's configuration to allow RSA keys
-  ansible.builtin.copy:
-    content: |
-      HostKeyAlgorithms +ssh-rsa
-      PubkeyAcceptedAlgorithms +ssh-rsa
-    dest: /etc/ssh/sshd_config.d/99-allow-rsakeys.conf
-    group: root
-    mode: 0644
-    owner: root
+  block:
+    - name: Allow RSA keys (OpenSSH < 8.5)
+      ansible.builtin.copy:
+        content: |
+          HostKeyAlgorithms +ssh-rsa
+          PubkeyAcceptedKeyTypes +ssh-rsa
+        dest: /etc/ssh/sshd_config.d/99-allow-rsakeys.conf
+        group: root
+        mode: 0644
+        owner: root
+      when: openssh_version is version("8.5", "<")
+    - name: Allow RSA keys (OpenSSH >= 8.5)
+      ansible.builtin.copy:
+        content: |
+          HostKeyAlgorithms +ssh-rsa
+          PubkeyAcceptedAlgorithms +ssh-rsa
+        dest: /etc/ssh/sshd_config.d/99-allow-rsakeys.conf
+        group: root
+        mode: 0644
+        owner: root
+      when: openssh_version is version("8.5", ">=")

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,2 +1,29 @@
 ---
-# tasks file for skeleton
+- name: Ensure that a directory for sshd config fragments exists
+  ansible.builtin.file:
+    group: root
+    mode: 0755
+    owner: root
+    path: /etc/ssh/sshd_config.d
+    state: directory
+
+- name: >
+    Make sure that sshd_config includes the files in the fragments
+    directory
+  ansible.builtin.lineinfile:
+    firstmatch: yes
+    # The Include directive must go at the top of the config file, so
+    # we want to place the line before the first non-comment line.
+    insertbefore: ^[^#\n]
+    line: Include /etc/ssh/sshd_config.d/*.conf
+    path: /etc/ssh/sshd_config
+
+- name: Modify sshd's configuration to allow RSA keys
+  ansible.builtin.copy:
+    content: |
+      HostKeyAlgorithms +ssh-rsa
+      PubkeyAcceptedAlgorithms +ssh-rsa
+    dest: /etc/ssh/sshd_config.d/99-allow-rsakeys.conf
+    group: root
+    mode: 0644
+    owner: root


### PR DESCRIPTION
## 🗣 Description ##

This pull request contains the initial commits for an Ansible role that modifies OpenSSH to allow connections with RSA keys.

## 💭 Motivation and context ##

This Ansible role is necessary for [the latest Kali AMI](), since the base AMI has OpenSSH 9.  The `sshd` in that version disallows RSA connections by default, and that is the only key type currently supported by Guacamole.

## 🧪 Testing ##

Tested as part of cisagov/kali-packer#111.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.