### PR TITLE
Alter regexes to work with latest OpenSSH for Debian Bookworm (12)

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,8 @@
 
 - name: Set facts for OpenSSH and OpenSSL versions
   ansible.builtin.set_fact:
-    openssh_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)  .+$', '\\1') | first }}"
-    openssl_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)  .+$', '\\2') | first }}"
+    openssh_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)\ +.+$', '\\1') | first }}"
+    openssl_version: "{{ ssh_version.stderr | regex_search('^OpenSSH_([^,]*)p.*, OpenSSL ([^\ ]*)\ +.+$', '\\2') | first }}"
 
 - name: Ensure that a directory for sshd config fragments exists
   ansible.builtin.file:


### PR DESCRIPTION
## 🗣 Description ##

This pull request alters two regexes so that they correctly handle the latest OpenSSH package for Debian Bookworm (12).

## 💭 Motivation and context ##

This Ansible role's GitHub Actions [began failing](https://github.com/cisagov/ansible-role-sshd-allow-rsa/runs/6906662359?check_suite_focus=true), which alerted me to identify and fix the issue.

## 🧪 Testing ##

All automated testing passes.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.